### PR TITLE
Python 3.5/3.6 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ target/
 .venv
 .project
 .pydevproject
+
+.envrc
+.direnv

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,71 @@ install:
 script:
   - tox
 
-env:
-  - TOXENV=py27-django17
-  - TOXENV=py27-django18
-  - TOXENV=py33-django17
-  - TOXENV=py33-django18
-  - TOXENV=py34-django17
-  - TOXENV=py34-django18
-  - TOXENV=pypy-django17
-  - TOXENV=pypy-django18
+matrix:
+  fast_finish: true
+  allow_failures:
+    # Python 2.7
+    - python: 2.7
+      env: TOXENV=py27-django18
+    - python: 2.7
+      env: TOXENV=py27-django19
+    - python: 2.7
+      env: TOXENV=py27-django110
+    - python: 2.7
+      env: TOXENV=py27-django111
+
+    # Python 3.4
+    - python: 3.4
+      env: TOXENV=py34-django111
+
+    # Python 3.5
+    - python: 3.5
+      env: TOXENV=py35-django111
+
+    # Python 3.6
+    - python: 3.6
+      env: TOXENV=py36-django111
+
+  include:
+    # Python 2.7
+    - python: 2.7
+      env: TOXENV=py27-django18
+    - python: 2.7
+      env: TOXENV=py27-django19
+    - python: 2.7
+      env: TOXENV=py27-django110
+    - python: 2.7
+      env: TOXENV=py27-django111
+
+    # Python 3.4
+    - python: 3.4
+      env: TOXENV=py34-django18
+    - python: 3.4
+      env: TOXENV=py34-django19
+    - python: 3.4
+      env: TOXENV=py34-django110
+    - python: 3.4
+      env: TOXENV=py34-django111
+
+    # Python 3.5
+    - python: 3.5
+      env: TOXENV=py35-django18
+    - python: 3.5
+      env: TOXENV=py35-django19
+    - python: 3.5
+      env: TOXENV=py35-django110
+    - python: 3.5
+      env: TOXENV=py35-django111
+
+    # Python 3.6
+    - python: 3.6
+      env: TOXENV=py36-django18
+    - python: 3.6
+      env: TOXENV=py36-django19
+    - python: 3.6
+      env: TOXENV=py36-django110
+    - python: 3.6
+      env: TOXENV=py36-django111
 
 after_success:
   - codecov

--- a/django_geopostcodes/helpers.py
+++ b/django_geopostcodes/helpers.py
@@ -6,12 +6,13 @@
     Helper functions for django-geopostcodes.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import csv
-from collections import namedtuple
+
 from django.contrib.gis.geos import Point
 from django.db.transaction import atomic
+
 from .models import Locality
-from django.utils.translation import ugettext_lazy as _
 
 
 def import_localities(path, delimiter=';'):
@@ -21,37 +22,19 @@ def import_localities(path, delimiter=';'):
     :param path: Path to the CSV file containing the localities.
     """
 
-    LocalityExpected = namedtuple('LocalityExpected',
-                              ('iso country language id region1 region2 '
-                               'region3 region4 locality postcode suburb '
-                               'latitude longitude elevation iso2 fips nuts '
-                               'hasc stat timezone utc dst'))
-
     creates = []
     updates = []
 
     with open(path, mode="r") as infile:
-        reader = csv.reader(infile, delimiter=str(delimiter))
-
-        # Get names from column headers
-        LocalityActual = namedtuple("LocalityActual", next(reader))
-
-        # Use names to very the format of the file
-        if LocalityActual._fields != LocalityExpected._fields:
-            raise Exception(_("Expected fields ({expected_fields}) in {path} not ({actual_fields})").format(
-                expected_fields=LocalityExpected._fields,
-                path=path,
-                actual_fields=LocalityActual._fields
-            ))
+        reader = csv.DictReader(infile, delimiter=str(delimiter))
 
         with atomic():
-            for row in map(LocalityExpected._make, reader):
-                defaults = row.__dict__
-                defaults['point'] = Point(float(row.longitude),
-                                          float(row.latitude))
+            for row in reader:
+                row['point'] = Point(float(row['longitude']),
+                                     float(row['latitude']))
                 locality, created = Locality.objects.update_or_create(
-                    id=row.id,
-                    defaults=defaults
+                    id=row['id'],
+                    defaults=row
                 )
                 if created:
                     creates.append(locality)

--- a/django_geopostcodes/management/commands/import_localities.py
+++ b/django_geopostcodes/management/commands/import_localities.py
@@ -6,8 +6,10 @@
     Import a GeoPostCodes Locality file.
 """
 from __future__ import absolute_import, print_function, unicode_literals
+
 import logging
 from optparse import make_option
+
 from django.core.management.base import BaseCommand, CommandError
 from django_geopostcodes.helpers import import_localities
 from django.utils.translation import ugettext_lazy as _

--- a/django_geopostcodes/tests/test_helpers.py
+++ b/django_geopostcodes/tests/test_helpers.py
@@ -7,7 +7,14 @@
 """
 from __future__ import absolute_import, print_function, unicode_literals
 import os
-from django.utils import unittest
+
+try:
+    # django 1.7
+    from django.utils.unittest import TestCase
+except ImportError:
+    # django 1.8+
+    from django.test import TestCase
+
 from ..helpers import import_localities
 from ..models import Locality
 
@@ -19,7 +26,7 @@ def create_sample_localities():
                       "\t")
 
 
-class ImportLocalitiesTestCase(unittest.TestCase):
+class ImportLocalitiesTestCase(TestCase):
 
     def test_import_localities(self):
         self.assertEqual(Locality.objects.count(), 0)

--- a/requirements/default-django17.txt
+++ b/requirements/default-django17.txt
@@ -1,2 +1,0 @@
-Django==1.7.8
-django-countries==3.3

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,2 +1,1 @@
-Django==1.8.5
-django-countries==3.3
+django-countries==4.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,5 @@
 -r test.txt
 -r pkgutils.txt
 -r docs.txt
+
+Django

--- a/requirements/pkgutils.txt
+++ b/requirements/pkgutils.txt
@@ -1,3 +1,2 @@
 setuptools>=1.3.2
 wheel
-tox

--- a/setup.py
+++ b/setup.py
@@ -26,17 +26,20 @@ extra = {}
 classes = """
     Development Status :: 4 - Beta
     Framework :: Django
-    Framework :: Django :: 1.7
     Framework :: Django :: 1.8
+    Framework :: Django :: 1.9
+    Framework :: Django :: 1.10
+    Framework :: Django :: 1.11
     License :: OSI Approved :: MIT License
     Intended Audience :: Developers
     Programming Language :: Python
     Programming Language :: Python :: 2
-    Programming Language :: Python :: 2.6
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.3
     Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Operating System :: OS Independent

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,16 @@
 [tox]
 envlist =
-    py{27,33,34,py}-django{17,18}
+    py{27,34,35,36,py}-django{18,19,110,111}
 
 [testenv]
 sitepackages = False
 commands = {toxinidir}/scripts/removepyc.sh {toxinidir}
            {toxinidir}/runtests.py
 deps =
-    django18: -r{toxinidir}/requirements/default.txt
-    django17: -r{toxinidir}/requirements/default-django17.txt
-    py{27,33,34,py}: -r{toxinidir}/requirements/test.txt
+    py{27,34,35,36,py}: -r{toxinidir}/requirements/test.txt
+
+    django111: Django>=1.11,<1.12
+    django110: Django>=1.10,<1.11
+    django19: Django>=1.9,<1.10
+    django18: Django>=1.8,<1.9
+    django17: Django>=1.7,<1.8


### PR DESCRIPTION
- Add support for Django 1.9 & 1.10 (with tests for 1.11 marked as allowed failures).
- Add support for Python 3.5 & 3.6.
- Discontinue support for Django 1.7.
- Discontinue support for Python 3.3.
- Mark Python 2.7 tests as allowed failures because of spatialite issues.